### PR TITLE
type attirbute of JS not needed in html5

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,10 +35,10 @@
     <p>Developed by <a href="http://www.hiddentao.com/archives/2012/04/01/google-tts-a-javascript-api-for-google-text-to-speech-engine/">Ramesh Nair</a>, based on code by <a href="http://weston.ruter.net/projects/google-tts/">Weston Ruter</a>.</p>
 </footer>
 
-<script type="text/javascript" src="./jquery-1.9.1.min.js"></script>
-<script type="text/javascript" src="./src/google-tts.js"></script>
-<script type="text/javascript" src="./soundmanager2.js"></script>
-<script type="text/javascript">
+<script src="./jquery-1.9.1.min.js"></script>
+<script src="./src/google-tts.js"></script>
+<script src="./soundmanager2.js"></script>
+<script>
     $(document).ready(function(){
       soundManager.setup({
         url: '/',


### PR DESCRIPTION
removed all type attributes of javascript, cos JS is default scripting language in html5